### PR TITLE
Add correct reuse badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 # Cloud compute operations
 
-[![REUSE status](https://api.reuse.software/badge/github.com/cobaltcore-dev/cloud-storage-operations)](https://api.reuse.software/info/github.com/cobaltcore-dev/cloud-storage-operations)
+[![REUSE status](https://api.reuse.software/badge/github.com/cobaltcore-dev/cloud-compute-operations)](https://api.reuse.software/info/github.com/cobaltcore-dev/cloud-compute-operations)
 
 This repository contains packaged resources and configuration related to the operations of the vendor-neutral cloud compute backend within the ApeiroRA project.
 


### PR DESCRIPTION
The previous reuse badge link seems to be copied from another repository, so I am fixing it in this PR: