### PR TITLE
(chore): migrate to cluster plugin definition

### DIFF
--- a/charts/kvm-operations/plugindefinition.yaml
+++ b/charts/kvm-operations/plugindefinition.yaml
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 apiVersion: greenhouse.sap/v1alpha1
-kind: PluginDefinition
+kind: ClusterPluginDefinition
 metadata:
   name: kvm-operations
 spec:


### PR DESCRIPTION
This PR migrates `PluginDefinition` CR to `ClusterPluginDefinition` CR to be used in greenhouse platform

The issue is documented here https://github.com/cloudoperators/greenhouse/issues/1004 and here https://github.com/cloudoperators/greenhouse/issues/1214

## Breaking Changes

- While this is breaking change, greenhouse controllers ensure smooth transition without any user action necessary